### PR TITLE
Bump atty dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "panser"
 
 [dependencies]
 ansi_term = "0.12"
-atty = "0.2"
+atty >= "0.2.14"
 bincode = "1"
 byteorder = "1"
 clap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "panser"
 
 [dependencies]
 ansi_term = "0.12"
-atty >= "0.2.14"
+atty = ">0.2.14"
 bincode = "1"
 byteorder = "1"
 clap = "2"


### PR DESCRIPTION
Bumps the `atty` dependency version to avoid a bug in older versions.